### PR TITLE
Implement stub AI service functions

### DIFF
--- a/lib/ai-service.ts
+++ b/lib/ai-service.ts
@@ -3,6 +3,9 @@
 // Update the AI service to consider health details when generating workout plans
 
 // In the function that prepares the prompt for the AI
+import type { UserProfile } from "@/types/fitness"
+import { mockExercises } from "./supabase"
+
 function preparePrompt(profile: any) {
   // Extract health details if available
   let healthDetailsText = ""
@@ -49,4 +52,67 @@ function preparePrompt(profile: any) {
   `
 
   return prompt
+}
+
+export async function generateWorkoutPlan(profile: UserProfile) {
+  // In a real implementation this would call an AI service using the prompt.
+  preparePrompt(profile)
+
+  const workouts = Array.from(
+    { length: profile.training_days_per_week || 3 },
+    (_, i) => ({
+      name: `Workout Day ${i + 1}`,
+      day_of_week: i % 7,
+      description: "Auto generated workout",
+      exercises: mockExercises.map((ex, idx) => ({
+        exercise_id: String(ex.id),
+        sets: 3,
+        reps_per_set: "8-12",
+        rest_seconds: 60,
+        order_index: idx + 1,
+        notes: "",
+      })),
+    }),
+  )
+
+  return {
+    name: "Starter Plan",
+    description: "Sample workout plan generated without AI.",
+    duration_weeks: 4,
+    workouts,
+  }
+}
+
+export async function getExerciseRecommendations(
+  profile: UserProfile,
+  recentWorkouts: any[],
+) {
+  // Recommend exercises not recently performed (stub implementation)
+  const recentIds = new Set(
+    recentWorkouts.flatMap((w) =>
+      (w.workout_exercises || []).map((we: any) => String(we.exercise_id)),
+    ),
+  )
+
+  const recommendations = mockExercises
+    .filter((ex) => !recentIds.has(String(ex.id)))
+    .map((ex) => ex.name)
+
+  return recommendations.slice(0, 5)
+}
+
+export async function generateProgressInsights(
+  profile: UserProfile,
+  workoutLogs: any[],
+) {
+  // Simple stub insights
+  if (!workoutLogs || workoutLogs.length === 0) {
+    return ["Start logging your workouts to see progress insights!"]
+  }
+
+  return [
+    "Great consistency! Keep it up.",
+    "Consider gradually increasing intensity for continued progress.",
+    "Remember to rest and recover between sessions.",
+  ]
 }


### PR DESCRIPTION
## Summary
- expand `lib/ai-service.ts` with exported AI service stubs
- include placeholder workout plan, recommendations and insights

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1dee1fc8325a514ab3e8f306327